### PR TITLE
Allow importing client without cross-fetch

### DIFF
--- a/src/GraphQLClient.ts
+++ b/src/GraphQLClient.ts
@@ -1,0 +1,94 @@
+import { ClientError, GraphQLError, Headers as HttpHeaders, Options, Variables } from './types'
+import getResult from './getResult'
+
+export default class GraphQLClient {
+  private url: string
+  private options: Options
+
+  constructor(url: string, options?: Options) {
+    this.url = url
+    this.options = options || {}
+  }
+
+  async rawRequest<T extends any>(
+    query: string,
+    variables?: Variables,
+  ): Promise<{ data?: T, extensions?: any, headers: Headers, status: number, errors?: GraphQLError[] }> {
+    const { headers, ...others } = this.options
+
+    const body = JSON.stringify({
+      query,
+      variables: variables ? variables : undefined,
+    })
+
+    const response = await fetch(this.url, {
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
+      body,
+      ...others,
+    })
+
+    const result = await getResult(response)
+
+    if (response.ok && !result.errors && result.data) {
+      const { headers, status } = response
+      return { ...result, headers, status }
+    } else {
+      const errorResult =
+        typeof result === 'string' ? { error: result } : result
+      throw new ClientError(
+        { ...errorResult, status: response.status, headers: response.headers },
+        { query, variables },
+      )
+    }
+  }
+
+  async request<T extends any>(
+    query: string,
+    variables?: Variables,
+  ): Promise<T> {
+    const { headers, ...others } = this.options
+
+    const body = JSON.stringify({
+      query,
+      variables: variables ? variables : undefined,
+    })
+
+    const response = await fetch(this.url, {
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
+      body,
+      ...others,
+    })
+
+    const result = await getResult(response)
+
+    if (response.ok && !result.errors && result.data) {
+      return result.data
+    } else {
+      const errorResult =
+        typeof result === 'string' ? { error: result } : result
+      throw new ClientError(
+        { ...errorResult, status: response.status },
+        { query, variables },
+      )
+    }
+  }
+
+  setHeaders(headers: HttpHeaders): GraphQLClient {
+    this.options.headers = headers
+
+    return this
+  }
+
+  setHeader(key: string, value: string): GraphQLClient {
+    const { headers } = this.options
+
+    if (headers) {
+      headers[key] = value
+    } else {
+      this.options.headers = { [key]: value }
+    }
+    return this
+  }
+}

--- a/src/getResult.ts
+++ b/src/getResult.ts
@@ -1,0 +1,8 @@
+export default async function getResult(response: Response): Promise<any> {
+  const contentType = response.headers.get('Content-Type')
+  if (contentType && contentType.startsWith('application/json')) {
+    return response.json()
+  } else {
+    return response.text()
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,126 +1,14 @@
-import { ClientError, GraphQLError, Headers as HttpHeaders, Options, Variables } from './types'
 export { ClientError } from './types'
 import 'cross-fetch/polyfill'
 
-export class GraphQLClient {
-  private url: string
-  private options: Options
+import GraphQLClient from './GraphQLClient'
+import rawRequest from './rawRequest'
+import request from './request'
 
-  constructor(url: string, options?: Options) {
-    this.url = url
-    this.options = options || {}
-  }
-
-  async rawRequest<T extends any>(
-    query: string,
-    variables?: Variables,
-  ): Promise<{ data?: T, extensions?: any, headers: Headers, status: number, errors?: GraphQLError[] }> {
-    const { headers, ...others } = this.options
-
-    const body = JSON.stringify({
-      query,
-      variables: variables ? variables : undefined,
-    })
-
-    const response = await fetch(this.url, {
-      method: 'POST',
-      headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
-      body,
-      ...others,
-    })
-
-    const result = await getResult(response)
-
-    if (response.ok && !result.errors && result.data) {
-      const { headers, status } = response
-      return { ...result, headers, status }
-    } else {
-      const errorResult =
-        typeof result === 'string' ? { error: result } : result
-      throw new ClientError(
-        { ...errorResult, status: response.status, headers: response.headers },
-        { query, variables },
-      )
-    }
-  }
-
-  async request<T extends any>(
-    query: string,
-    variables?: Variables,
-  ): Promise<T> {
-    const { headers, ...others } = this.options
-
-    const body = JSON.stringify({
-      query,
-      variables: variables ? variables : undefined,
-    })
-
-    const response = await fetch(this.url, {
-      method: 'POST',
-      headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
-      body,
-      ...others,
-    })
-
-    const result = await getResult(response)
-
-    if (response.ok && !result.errors && result.data) {
-      return result.data
-    } else {
-      const errorResult =
-        typeof result === 'string' ? { error: result } : result
-      throw new ClientError(
-        { ...errorResult, status: response.status },
-        { query, variables },
-      )
-    }
-  }
-
-  setHeaders(headers: HttpHeaders): GraphQLClient {
-    this.options.headers = headers
-
-    return this
-  }
-
-  setHeader(key: string, value: string): GraphQLClient {
-    const { headers } = this.options
-
-    if (headers) {
-      headers[key] = value
-    } else {
-      this.options.headers = { [key]: value }
-    }
-    return this
-  }
-}
-
-export async function rawRequest<T extends any>(
-  url: string,
-  query: string,
-  variables?: Variables,
-): Promise<{ data?: T, extensions?: any, headers: Headers, status: number, errors?: GraphQLError[] }> {
-  const client = new GraphQLClient(url)
-
-  return client.rawRequest<T>(query, variables)
-}
-
-export async function request<T extends any>(
-  url: string,
-  query: string,
-  variables?: Variables,
-): Promise<T> {
-  const client = new GraphQLClient(url)
-
-  return client.request<T>(query, variables)
+export {
+  GraphQLClient,
+  rawRequest,
+  request,
 }
 
 export default request
-
-async function getResult(response: Response): Promise<any> {
-  const contentType = response.headers.get('Content-Type')
-  if (contentType && contentType.startsWith('application/json')) {
-    return response.json()
-  } else {
-    return response.text()
-  }
-}

--- a/src/rawRequest.ts
+++ b/src/rawRequest.ts
@@ -1,0 +1,12 @@
+import { GraphQLError, Variables } from './types'
+import GraphQLClient from './GraphQLClient'
+
+export default async function rawRequest<T extends any>(
+  url: string,
+  query: string,
+  variables?: Variables,
+): Promise<{ data?: T, extensions?: any, headers: Headers, status: number, errors?: GraphQLError[] }> {
+  const client = new GraphQLClient(url)
+
+  return client.rawRequest<T>(query, variables)
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,12 @@
+import GraphQLClient from './GraphQLClient'
+import { Variables } from './types'
+
+export default async function request<T extends any>(
+  url: string,
+  query: string,
+  variables?: Variables,
+): Promise<T> {
+  const client = new GraphQLClient(url)
+
+  return client.request<T>(query, variables)
+}


### PR DESCRIPTION
## What
Divide src/index.ts into:

- src/GraphQLClient.ts
- src/getResult.ts
- src/index.ts
- src/rawRequest.ts
- src/request.ts

so developers can import GraphQLClient by

```ts
import GraphQLClient from "graphql-request/dist/src/GraphQLClient"
```

without importing "cross-fetch/polyfill"

## Why
- https://github.com/prismagraphql/graphql-request/issues/40
- Enable to reduce bundle size a bit.
    - Projects which only imports `GraphQLClient` can avoid bundling `request()` and `rawRequest()`.
- Structured files improve readability. Don't you think so?