### PR TITLE
feat: support parsed query

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,15 @@
     "@types/node": "8.5.5",
     "ava": "0.25.0",
     "fetch-mock": "5.13.1",
+    "graphql-tag": "2.9.2",
     "tslint": "5.9.1",
     "tslint-config-standard": "7.0.0",
     "typescript": "2.7.2"
   },
   "dependencies": {
     "cross-fetch": "2.0.0"
+  },
+  "peerDependencies": {
+    "graphql": "0.13.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ClientError, GraphQLError, Headers as HttpHeaders, Options, Variables } from './types'
 export { ClientError } from './types'
 import 'cross-fetch/polyfill'
-
+import { print } from 'graphql'
 export class GraphQLClient {
   private url: string
   private options: Options
@@ -45,13 +45,13 @@ export class GraphQLClient {
   }
 
   async request<T extends any>(
-    query: string,
+    query: string | object,
     variables?: Variables,
   ): Promise<T> {
     const { headers, ...others } = this.options
-
+    const printedQuery = typeof query === 'object' ? print(query) : query
     const body = JSON.stringify({
-      query,
+      query: printedQuery,
       variables: variables ? variables : undefined,
     })
 
@@ -71,7 +71,7 @@ export class GraphQLClient {
         typeof result === 'string' ? { error: result } : result
       throw new ClientError(
         { ...errorResult, status: response.status },
-        { query, variables },
+        { query: printedQuery, variables },
       )
     }
   }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,6 +2,7 @@ import test from 'ava'
 import * as fetchMock from 'fetch-mock'
 import { ClientError, rawRequest, request, GraphQLClient } from '../src/index'
 import { Options } from '../src/types'
+import gql from 'graphql-tag'
 
 test('minimal query', async (t) => {
   const data = {
@@ -122,6 +123,21 @@ test('extra fetch options', async (t) => {
       t.deepEqual(actualOptions[name], options[name])
     }
   })
+})
+
+test('minimal parsed query', async (t) => {
+  const data = {
+    Actor: {
+      name: "Tom Hardy"
+    }
+  }
+
+  /*
+  This test is flaky because it relies on the internet 
+  but the mock passed for this feature (parsed query) without
+  the implementation. 
+  */
+  t.deepEqual(await request('https://api.graph.cool/simple/v1/movies', gql`query { Actor(name: "Tom Hardy") { name } }`), data)
 })
 
 async function mock(response: any, testFn: () => Promise<void>) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "outDir": "dist",
-    "lib": ["es2015", "es2016", "dom"]
+    "lib": ["es2015", "es2016", "dom", "esnext"]
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Test with mock passes without the feature as `gql` return type is `any`. Hence, I had to write a test that depends on internet and might be flaky. We can work on providing for a better mock API. 